### PR TITLE
Store attributes as JSON in Redis

### DIFF
--- a/load_sample.py
+++ b/load_sample.py
@@ -1,95 +1,80 @@
-import csv 
-import pika 
-import jinja2
-import redis
+import csv
 import json
+import os
 import sys
 import uuid
-import os
+
+import jinja2
+import pika
+import redis
 
 # get rabbitmq env vars
-rabbitmq_host       = os.environ.get('RABBITMQ_SERVICE_HOST', 'localhost')
-rabbitmq_port       = os.environ.get('RABBITMQ_SERVICE_PORT', '5672')
-rabbitmq_vhost      = os.environ.get('RABBITMQ_VHOST', '/')
-rabbitmq_queue      = os.environ.get('RABBITMQ_QUEUE', 'localtest')
-rabbitmq_exchange   = os.environ.get('RABBITMQ_EXCHANGE', '')
-rabbitmq_user       = os.environ.get('RABBITMQ_USER', 'guest')
-rabbitmq_password   = os.environ.get('RABBITMQ_PASSWORD', 'guest')
+rabbitmq_host = os.environ.get('RABBITMQ_SERVICE_HOST', 'localhost')
+rabbitmq_port = os.environ.get('RABBITMQ_SERVICE_PORT', '5672')
+rabbitmq_vhost = os.environ.get('RABBITMQ_VHOST', '/')
+rabbitmq_queue = os.environ.get('RABBITMQ_QUEUE', 'localtest')
+rabbitmq_exchange = os.environ.get('RABBITMQ_EXCHANGE', '')
+rabbitmq_user = os.environ.get('RABBITMQ_USER', 'guest')
+rabbitmq_password = os.environ.get('RABBITMQ_PASSWORD', 'guest')
 
 # rabbit global vars
 rabbitmq_credentials = None
-rabbitmq_connection  = None
-rabbitmq_channel     = None
+rabbitmq_connection = None
+rabbitmq_channel = None
 
 # get redis env vars
-redis_host       = os.environ.get('REDIS_SERVICE_HOST', 'localhost')
-redis_port       = os.environ.get('REDIS_SERVICE_PORT', '6379')
-redis_db         = os.environ.get('REDIS_DB', '0')         
-
+redis_host = os.environ.get('REDIS_SERVICE_HOST', 'localhost')
+redis_port = os.environ.get('REDIS_SERVICE_PORT', '6379')
+redis_db = os.environ.get('REDIS_DB', '0')
 
 # globally load sampleunit message template
-env = jinja2.Environment(loader=jinja2.FileSystemLoader(["./"])) 
-jinja_template = env.get_template( "message_template.xml") 
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(["./"]))
+jinja_template = env.get_template("message_template.xml")
 
 
-
-def sample_reader(file_obj,ce_uuid,ap_uuid,ci_uuid):
-   
+def sample_reader(file_obj, ce_uuid, ap_uuid, ci_uuid):
     sampleunits = {}
     reader = csv.DictReader(file_obj, delimiter=',')
     count = 0
     for sampleunit in reader:
         sample_id = uuid.uuid4()
-        sampleunits.update( {"sampleunit:"+str(sample_id) : create_json(sample_id,sampleunit)} )
-        publish_sampleunit (jinja_template.render(sample=sampleunit, uuid=sample_id , ce_uuid=ce_uuid ,ap_uuid=ap_uuid , ci_uuid=ci_uuid))
+        sampleunits.update({"sampleunit:" + str(sample_id): create_json(sample_id, sampleunit)})
+        publish_sampleunit(
+            jinja_template.render(sample=sampleunit, uuid=sample_id, ce_uuid=ce_uuid, ap_uuid=ap_uuid, ci_uuid=ci_uuid))
         count += 1
         if count % 5000 == 0:
             sys.stdout.write("\r" + str(count) + " samples loaded")
             sys.stdout.flush()
-    
-    print('\nAll Sample Units have been added to the queue ' +rabbitmq_queue )
-    rabbitmq_connection.close()
+
+    print('\nAll Sample Units have been added to the queue ' + rabbitmq_queue)
     write_sampleunits_to_redis(sampleunits)
 
 
+def create_json(sample_id, sampleunit):
+    sampleunit = {"id": str(sample_id), "attributes": sampleunit}
 
-def create_json(sample_id,sampleunit):
-    
-    obj = {"id":str(sample_id),"attributes":{}}
-    attrs = {}
-    
-    # having to add attributes like this as json.dumps double escapes the quotes
-    for key in sampleunit:
-        attrs.update({str(key) : str(sampleunit[key])})
-
-    obj.update({"attributes":attrs })
-    return obj
-
+    return json.dumps(sampleunit)
 
 
 def publish_sampleunit(message):
-   
     rabbitmq_channel.basic_publish(exchange=rabbitmq_exchange,
-                      routing_key=rabbitmq_queue,
-                      body=str(message),
-                      properties=pika.BasicProperties(content_type='text/xml')
-                    )
-
+                                   routing_key=rabbitmq_queue,
+                                   body=str(message),
+                                   properties=pika.BasicProperties(content_type='text/xml'))
 
 
 def init_rabbit():
-    global rabbitmq_credentials, rabbitmq_connection, rabbitmq_channel 
+    global rabbitmq_credentials, rabbitmq_connection, rabbitmq_channel
     rabbitmq_credentials = pika.PlainCredentials(rabbitmq_user, rabbitmq_password)
     rabbitmq_connection = pika.BlockingConnection(
-                        pika.ConnectionParameters(rabbitmq_host,
-                                                  rabbitmq_port,
-                                                  rabbitmq_vhost,
-                                                  rabbitmq_credentials))
+        pika.ConnectionParameters(rabbitmq_host,
+                                  rabbitmq_port,
+                                  rabbitmq_vhost,
+                                  rabbitmq_credentials))
     rabbitmq_channel = rabbitmq_connection.channel()
 
     if rabbitmq_queue == 'localtest':
         rabbitmq_channel.queue_declare(queue=rabbitmq_queue)
-
 
 
 def write_sampleunits_to_redis(sampleunits):
@@ -98,26 +83,27 @@ def write_sampleunits_to_redis(sampleunits):
     print("Writing sampleunits to Redis")
     count = 0
     redis_pipeline = redis_connection.pipeline()
-    for key in sampleunits:
-        redis_connection.set(key, sampleunits[key])
+    for key, attributes in sampleunits.items():
+        print(attributes)
+        redis_connection.set(key, attributes)
         count += 1
         if count % 5000 == 0:
             sys.stdout.write("\r" + str(count) + " samples loaded")
             sys.stdout.flush()
 
-
     redis_pipeline.execute()
     print("Sample Units written to Redis")
-    
 
-#------------------------------------------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------------------------------------------
 # Usage python loadSample.py <SAMPLE.csv> <COLLECTION_EXERCISE_UUID> <ACTIONPLAN_UUID> <COLLECTION_INSTRUMENT_UUID>
-#------------------------------------------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------------------------------------------
 
 if __name__ == "__main__":
     if len(sys.argv) < 4:
-      print('Usage python loadSample.py sample.csv <COLLECTION_EXERCISE_UUID> <ACTIONPLAN_UUID> <COLLECTION_INSTRUMENT_UUID>')
+        print(
+            'Usage python loadSample.py sample.csv <COLLECTION_EXERCISE_UUID> <ACTIONPLAN_UUID> <COLLECTION_INSTRUMENT_UUID>')
     else:
-      init_rabbit()
-      with open(sys.argv[1]) as f_obj:
-         sample_reader(f_obj,sys.argv[2],sys.argv[3],sys.argv[4]) 
+        init_rabbit()
+        with open(sys.argv[1]) as f_obj:
+            sample_reader(f_obj, sys.argv[2], sys.argv[3], sys.argv[4])

--- a/load_sample.py
+++ b/load_sample.py
@@ -47,6 +47,7 @@ def sample_reader(file_obj, ce_uuid, ap_uuid, ci_uuid):
             sys.stdout.flush()
 
     print('\nAll Sample Units have been added to the queue ' + rabbitmq_queue)
+    rabbitmq_connection.close()
     write_sampleunits_to_redis(sampleunits)
 
 

--- a/load_sample.py
+++ b/load_sample.py
@@ -84,7 +84,6 @@ def write_sampleunits_to_redis(sampleunits):
     count = 0
     redis_pipeline = redis_connection.pipeline()
     for key, attributes in sampleunits.items():
-        print(attributes)
         redis_connection.set(key, attributes)
         count += 1
         if count % 5000 == 0:


### PR DESCRIPTION
### Motivation and Context
The loader was storing the sample attributes as string representations of python dictionaries, then the sample service stub would attempt to convert this to JSON when it retrieved them. However this was causing problems in sample files where the attribute fields contained apostrophes so the sample stub would return invalid JSON.

### What has Changed
- Use json.dumps to format sample units before sending to redis
- Run auto formatter

### How to Test
Run the sample load process with the corresponding branch of the sample service stub https://github.com/ONSdigital/census-rm-sample/pull/1 using a sample file containing apostrophes, it should now be able to successfully retrieve attributes and generate the print file.

### Links
https://trello.com/c/RNdmBBDk/454-handle-apostrophes-in-catd-sample-load-process
https://github.com/ONSdigital/census-rm-sample/pull/1