### PR TITLE
Automate census docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,18 @@ services:
   - docker
 
 after_success:
-- echo $TRAVIS_BRANCH
-- echo $TRAVIS_PULL_REQUEST
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
-  echo "RUNNING IN HERE"
-  docker build -t "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader .;
+  docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker push "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader;
+  docker push "$DESTINATION_IMAGE_NAME";
   fi
 - bash <(curl -s https://codecov.io/bash)
 
 env:
-  - secure: ol0EDEa6z4g4DlbmGijpTrDf4OBaBW6OnD0YbhaD7tLGmW/HyxFlR8Wnhl2RZjNBXt+fw8yypVeNYn2enbiI5omWTdk110bZSWh97X1+0nFdf4UVBIXp8y36XTeQx9KiqwZC2mveX1z9CwI4/a+o3AOisUoUjiB5N9SbOteMHNckkZ2dHezfzBsbSNXB2kn+/tAYQCKqXrTGkpsMtdvO8LhVX7U7srqEqFAsBg2ZDY2Ry0SFLbm0QjwH+p31Y0oCvhNL8/XiYzpjiJZGtQzgWRnZ3vFbLmPg0zfgFqSqujiC6D9fZ81b3U7X6TJsOv7Hm6Ci2703MgSI9MaooRe/FE9AKowE9czoZiWVj3Uy8W9ojOJs3ipHJWDNuR4/Jnb/8Qny1tYFL7+nv+jGOJlaZwBkYsaQZGnra92tDHqkOBIm8dE67QCE39JqPVMN2BinWZnvIt0/CJfNL766QXiFV0oJbkVphFUnQQzJfOX6fwzyLRAaaHrqQ1flJVf1eLa4JG7YjRLSNySzJJ/x3ks9szTnOEiv9GbKInspDyEODckNAh6t9QVtNlQuKXh41Fhhcvrw+eOk7MbFOlRnk6pRGgNlzKWJycnHl2Yoft9fIlFO+4tCd3tL5zXxMc6SNV8x3vnlmYxkKn1idADML5dI8hXSudLnQakI+SkcvogaRTM=
+  global:
+    - secure: ol0EDEa6z4g4DlbmGijpTrDf4OBaBW6OnD0YbhaD7tLGmW/HyxFlR8Wnhl2RZjNBXt+fw8yypVeNYn2enbiI5omWTdk110bZSWh97X1+0nFdf4UVBIXp8y36XTeQx9KiqwZC2mveX1z9CwI4/a+o3AOisUoUjiB5N9SbOteMHNckkZ2dHezfzBsbSNXB2kn+/tAYQCKqXrTGkpsMtdvO8LhVX7U7srqEqFAsBg2ZDY2Ry0SFLbm0QjwH+p31Y0oCvhNL8/XiYzpjiJZGtQzgWRnZ3vFbLmPg0zfgFqSqujiC6D9fZ81b3U7X6TJsOv7Hm6Ci2703MgSI9MaooRe/FE9AKowE9czoZiWVj3Uy8W9ojOJs3ipHJWDNuR4/Jnb/8Qny1tYFL7+nv+jGOJlaZwBkYsaQZGnra92tDHqkOBIm8dE67QCE39JqPVMN2BinWZnvIt0/CJfNL766QXiFV0oJbkVphFUnQQzJfOX6fwzyLRAaaHrqQ1flJVf1eLa4JG7YjRLSNySzJJ/x3ks9szTnOEiv9GbKInspDyEODckNAh6t9QVtNlQuKXh41Fhhcvrw+eOk7MbFOlRnk6pRGgNlzKWJycnHl2Yoft9fIlFO+4tCd3tL5zXxMc6SNV8x3vnlmYxkKn1idADML5dI8hXSudLnQakI+SkcvogaRTM=
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-collectioninstrumentsvc"
 
 branches:
   only:
-    - rm-census
     - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - pipenv check
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker push "$DESTINATION_IMAGE_NAME";
@@ -30,4 +30,4 @@ env:
 
 branches:
   only:
-    - automate-census-docker-build
+    - rm-census

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,19 @@ sudo: required
 services:
   - docker
 
-before_install:
+language: python
+
+python:
+  - "3.6"
+
+install:
+  - pip install pipenv
+  - pipenv install --dev --deploy
+
+script:
+  - pipenv check
+
+after_success:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
@@ -14,6 +26,7 @@ before_install:
 env:
   global:
     - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-sample-loader"
+    - PIPENV_IGNORE_VIRTUALENVS=1
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+services:
+  - docker
+
+after_success:
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+  docker build -t "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader .;
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker push "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader;
+  fi
+- bash <(curl -s https://codecov.io/bash)
+
+env:
+  - secure: ol0EDEa6z4g4DlbmGijpTrDf4OBaBW6OnD0YbhaD7tLGmW/HyxFlR8Wnhl2RZjNBXt+fw8yypVeNYn2enbiI5omWTdk110bZSWh97X1+0nFdf4UVBIXp8y36XTeQx9KiqwZC2mveX1z9CwI4/a+o3AOisUoUjiB5N9SbOteMHNckkZ2dHezfzBsbSNXB2kn+/tAYQCKqXrTGkpsMtdvO8LhVX7U7srqEqFAsBg2ZDY2Ry0SFLbm0QjwH+p31Y0oCvhNL8/XiYzpjiJZGtQzgWRnZ3vFbLmPg0zfgFqSqujiC6D9fZ81b3U7X6TJsOv7Hm6Ci2703MgSI9MaooRe/FE9AKowE9czoZiWVj3Uy8W9ojOJs3ipHJWDNuR4/Jnb/8Qny1tYFL7+nv+jGOJlaZwBkYsaQZGnra92tDHqkOBIm8dE67QCE39JqPVMN2BinWZnvIt0/CJfNL766QXiFV0oJbkVphFUnQQzJfOX6fwzyLRAaaHrqQ1flJVf1eLa4JG7YjRLSNySzJJ/x3ks9szTnOEiv9GbKInspDyEODckNAh6t9QVtNlQuKXh41Fhhcvrw+eOk7MbFOlRnk6pRGgNlzKWJycnHl2Yoft9fIlFO+4tCd3tL5zXxMc6SNV8x3vnlmYxkKn1idADML5dI8hXSudLnQakI+SkcvogaRTM=
+
+branches:
+  only:
+    - rm-census
+    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ sudo: required
 services:
   - docker
 
-language: python
-
-python:
-  - "3.6"
-
-after_success:
+before_install:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ services:
   - docker
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+- echo $TRAVIS_BRANCH
+- echo $TRAVIS_PULL_REQUEST
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+  echo "RUNNING IN HERE"
   docker build -t "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader .;
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker push "${DOCKER_GCP_LOCATION}"/census-rm-sample-loader;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 services:
   - docker
 
+language: python
+
+python:
+  - "3.6"
+
 after_success:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker build -t "$DESTINATION_IMAGE_NAME" .;
@@ -13,8 +18,7 @@ after_success:
 
 env:
   global:
-    - secure: ol0EDEa6z4g4DlbmGijpTrDf4OBaBW6OnD0YbhaD7tLGmW/HyxFlR8Wnhl2RZjNBXt+fw8yypVeNYn2enbiI5omWTdk110bZSWh97X1+0nFdf4UVBIXp8y36XTeQx9KiqwZC2mveX1z9CwI4/a+o3AOisUoUjiB5N9SbOteMHNckkZ2dHezfzBsbSNXB2kn+/tAYQCKqXrTGkpsMtdvO8LhVX7U7srqEqFAsBg2ZDY2Ry0SFLbm0QjwH+p31Y0oCvhNL8/XiYzpjiJZGtQzgWRnZ3vFbLmPg0zfgFqSqujiC6D9fZ81b3U7X6TJsOv7Hm6Ci2703MgSI9MaooRe/FE9AKowE9czoZiWVj3Uy8W9ojOJs3ipHJWDNuR4/Jnb/8Qny1tYFL7+nv+jGOJlaZwBkYsaQZGnra92tDHqkOBIm8dE67QCE39JqPVMN2BinWZnvIt0/CJfNL766QXiFV0oJbkVphFUnQQzJfOX6fwzyLRAaaHrqQ1flJVf1eLa4JG7YjRLSNySzJJ/x3ks9szTnOEiv9GbKInspDyEODckNAh6t9QVtNlQuKXh41Fhhcvrw+eOk7MbFOlRnk6pRGgNlzKWJycnHl2Yoft9fIlFO+4tCd3tL5zXxMc6SNV8x3vnlmYxkKn1idADML5dI8hXSudLnQakI+SkcvogaRTM=
-    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-collectioninstrumentsvc"
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-sample-loader"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ env:
 
 branches:
   only:
-    - rm-census
+    - master


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/SLBH8XU6/468-create-travis-build-files-for-non-java-github-repos)