### PR TITLE
Follow library logging practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ While the sample loader pod is running, from another shell run
 ```bash
 kubectl cp <path_to_sample_file> <namespace>/<sample_load_pod_name>:<destination_path_on_pod>
 ```
+
+## Logging
+You can set the global log level with the `LOG_LEVEL` environment variable, when the sample loader runs as a script it defaults to `INFO` logging from script itself and `ERROR` for other log sources (e.g. pika).


### PR DESCRIPTION
## Motivation and Context
This code is now being imported as a library so should follow library logging practices
Also the logging of the count of sample units loaded was slightly off.

## What has Changed
* Replace direct stdout writes with logger calls
* Set the logger handler to the null handler
* Log to stdout when run as a script
* Update README

## How to test
Run the sample loader script, it should now log INFO log lines, try setting different global log levels with the `LOG_LEVEL` env var.