### PR TITLE
fix msg persistence

### DIFF
--- a/rabbit_context.py
+++ b/rabbit_context.py
@@ -1,6 +1,7 @@
 import os
 
 import pika
+from pika.spec import PERSISTENT_DELIVERY_MODE
 
 from exceptions import RabbitConnectionClosedError
 
@@ -51,4 +52,5 @@ class RabbitContext:
         self._channel.basic_publish(exchange=self._exchange,
                                     routing_key=self.queue_name,
                                     body=message,
-                                    properties=pika.BasicProperties(content_type=content_type))
+                                    properties=pika.BasicProperties(content_type=content_type,
+                                                                    delivery_mode=PERSISTENT_DELIVERY_MODE))

--- a/tests/test_rabbit_context.py
+++ b/tests/test_rabbit_context.py
@@ -32,7 +32,7 @@ class TestRabbitContext(TestCase):
         with RabbitContext() as rabbit:
             rabbit.publish_message('Test message body', 'text')
 
-        patch_pika.BasicProperties.assert_called_once_with(content_type='text')
+        patch_pika.BasicProperties.assert_called_once_with(content_type='text', delivery_mode=2)
         patched_basic_publish = patch_pika.BlockingConnection.return_value.channel.return_value.basic_publish
         patched_basic_publish.assert_called_once_with(exchange=rabbit._exchange,
                                                       routing_key=rabbit.queue_name,


### PR DESCRIPTION
Motivation
Messages send to rabbitmq weren't being sent with deliveryMode=Persistent

Changes
Change the rabbit publish properties to deliveryMode=Persistent

To Test
Locally with a clean docker dev, use this version of sample-loader to load a sample file:
pipenv run python load_sample.py sample_file.csv d432f918-1444-4483-bd5e-3abd51882c17 774d478f-fcd5-4a21-8293-e68d9c877679  

Then check the rabbit case.sample.inbound queue that all the msgs are persistent 


