### PR TITLE
Send CE Unit Address Level to Field

### DIFF
--- a/generate_sample_file.py
+++ b/generate_sample_file.py
@@ -115,7 +115,7 @@ class SampleGenerator:
         return self.CE_TYPES[random.randint(0, len(self.CE_TYPES) - 1)]
 
     @staticmethod
-    def random_is_community_estab_address_type_or_level():
+    def random_1_in_11():
         return random.randint(0, 10) > 9
 
     @staticmethod
@@ -137,17 +137,17 @@ class SampleGenerator:
                 for _ in range(item["quantity"]):
 
                     # randomly decide whether to create a CE case or not
-                    if self.random_is_community_estab_address_type_or_level():
+                    if self.random_1_in_11():
                         self._write_estab_case(writer, sequential_arid, item)
                         continue
 
                     # otherwise write a non CE case
                     self._write_row(writer, sequential_arid, False, 'U', item,
-                                    0)  # have to change this when intorducing SPG cases as they can be 'E' or 'U'
+                                    0)  # have to change this when introducing SPG cases as they can be 'E' or 'U'
 
     def _write_estab_case(self, writer, sequential_arid, item):
         #  randomly decide if we want to create a CE/U case
-        if self.random_is_community_estab_address_type_or_level():
+        if self.random_1_in_11():
             self._write_parent_and_unit_cases(writer, sequential_arid, item)
             return
 

--- a/generate_sample_file.py
+++ b/generate_sample_file.py
@@ -115,7 +115,7 @@ class SampleGenerator:
         return self.CE_TYPES[random.randint(0, len(self.CE_TYPES) - 1)]
 
     @staticmethod
-    def random_is_community_estab():
+    def random_is_community_estab_address_type_or_level():
         return random.randint(0, 10) > 9
 
     @staticmethod
@@ -135,36 +135,74 @@ class SampleGenerator:
 
             for item in treatment_code_quantities:
                 for _ in range(item["quantity"]):
-                    community_establishment = self.random_is_community_estab()
 
-                    writer.writerow({
-                        'ARID': self.get_sequential_arid() if sequential_arid else self.get_random_arid(),
-                        'ESTAB_ARID': self.get_random_arid(),
-                        'UPRN': self.get_random_uprn(),
-                        'ADDRESS_TYPE': 'CE' if community_establishment else "HH",
-                        'ESTAB_TYPE': self.get_random_ce_type() if community_establishment else 'Household',
-                        'ADDRESS_LEVEL': 'E' if community_establishment else 'U',
-                        'ABP_CODE': self.get_random_abp_code(),
-                        'ORGANISATION_NAME': '',
-                        'ADDRESS_LINE1': self.get_random_address_line(),
-                        'ADDRESS_LINE2': '',
-                        'ADDRESS_LINE3': '',
-                        'TOWN_NAME': self.get_random_post_town(),
-                        'POSTCODE': self.get_random_post_code(),
-                        'LATITUDE': self.get_random_lat_or_long(),
-                        'LONGITUDE': self.get_random_lat_or_long(),
-                        'OA': self.get_random_regiony_type_thing(),
-                        'LSOA': self.get_random_regiony_type_thing(),
-                        'MSOA': self.get_random_regiony_type_thing(),
-                        'LAD': self.get_random_regiony_type_thing(),
-                        'REGION': self.get_random_regiony_type_thing(),
-                        'HTC_WILLINGNESS': self.get_random_htc(),
-                        'HTC_DIGITAL': self.get_random_htc(),
-                        'TREATMENT_CODE': item["treatment_code"],
-                        'FIELDCOORDINATOR_ID': '',
-                        'FIELDOFFICER_ID': '',
-                        'CE_EXPECTED_CAPACITY': self.get_random_ce_capacity() if community_establishment else '',
-                    })
+                    # randomly decide whether to create a CE case or not
+                    if self.random_is_community_estab_address_type_or_level():
+                        self._write_estab_case(writer, sequential_arid, item)
+                        continue
+
+                    # otherwise write a non CE case
+                    self._write_row(writer, sequential_arid, False, 'U', item,
+                                    0)  # have to change this when intorducing SPG cases as they can be 'E' or 'U'
+
+    def _write_estab_case(self, writer, sequential_arid, item):
+        #  randomly decide if we want to create a CE/U case
+        if self.random_is_community_estab_address_type_or_level():
+            self._write_parent_and_unit_cases(writer, sequential_arid, item)
+            return
+
+        # otherwise write CE/E case
+        self._write_row(writer, sequential_arid, True, 'E', item, self.get_random_ce_capacity())
+
+    def _write_parent_and_unit_cases(self, writer, sequential_arid, item):
+        # create parent case
+        parent_arid, estab_type = self._write_row(writer, sequential_arid, True, 'E', item, 0)
+
+        # create child cases
+        for _ in range(10):
+            self._write_row(writer, sequential_arid, True, 'U', item, self.get_random_ce_capacity(), parent_arid,
+                            estab_type)
+
+    def _write_row(self, writer, sequential_arid, community_establishment, community_level, item, expected_capacity,
+                   estab_arid=None, estab_type=None):
+        arid = self.get_sequential_arid() if sequential_arid else self.get_random_arid()
+
+        if estab_type is None:
+            estab_type = self.get_random_ce_type() if community_establishment else 'Household'
+
+        if estab_arid is None:
+            estab_arid = self.get_random_arid()
+
+        writer.writerow({
+            'ARID': arid,
+            'ESTAB_ARID': estab_arid,
+            'UPRN': self.get_random_uprn(),
+            'ADDRESS_TYPE': 'CE' if community_establishment else "HH",
+            'ESTAB_TYPE': estab_type,
+            'ADDRESS_LEVEL': community_level if community_establishment else 'U',
+            'ABP_CODE': self.get_random_abp_code(),
+            'ORGANISATION_NAME': '',
+            'ADDRESS_LINE1': self.get_random_address_line(),
+            'ADDRESS_LINE2': '',
+            'ADDRESS_LINE3': '',
+            'TOWN_NAME': self.get_random_post_town(),
+            'POSTCODE': self.get_random_post_code(),
+            'LATITUDE': self.get_random_lat_or_long(),
+            'LONGITUDE': self.get_random_lat_or_long(),
+            'OA': self.get_random_regiony_type_thing(),
+            'LSOA': self.get_random_regiony_type_thing(),
+            'MSOA': self.get_random_regiony_type_thing(),
+            'LAD': self.get_random_regiony_type_thing(),
+            'REGION': self.get_random_regiony_type_thing(),
+            'HTC_WILLINGNESS': self.get_random_htc(),
+            'HTC_DIGITAL': self.get_random_htc(),
+            'TREATMENT_CODE': item["treatment_code"],
+            'FIELDCOORDINATOR_ID': '',
+            'FIELDOFFICER_ID': '',
+            'CE_EXPECTED_CAPACITY': expected_capacity
+        })
+
+        return arid, estab_type
 
 
 def parse_arguments():

--- a/generate_sample_file.py
+++ b/generate_sample_file.py
@@ -161,7 +161,7 @@ class SampleGenerator:
                                                   community_level='E', expected_capacity=0)
 
         # create child cases
-        for _ in range(10):
+        for _ in range(3):
             self._write_row(writer, sequential_arid, treatment_code,
                             self.get_random_ce_capacity(),
                             community_establishment=True, community_level='U', estab_arid=parent_arid,


### PR DESCRIPTION
# Motivation and Context
Need to be able to identify unit level cases so that field officers know how many responses to expect per CE/E

# What has changed
Links Unit Level address CE cases to their parent CE/E case via ARID/ESTAB ARID. Now shows unit level expected capacity against parent estab case. Randomly generates a sample of various address types/levels

# How to test?
Clone repo and run tests locally

# Links
https://trello.com/c/dYHyciu0