### PR TITLE
Make sample unit logging frequency configurable

### DIFF
--- a/load_sample.py
+++ b/load_sample.py
@@ -35,7 +35,7 @@ def load_sample(sample_file: Iterable[str], collection_exercise_id: str, action_
 
 
 def _load_sample_units(action_plan_id: str, collection_exercise_id: str, sample_file_reader: Iterable[str],
-                       store_loaded_sample_units=False, **kwargs):
+                       store_loaded_sample_units=False, sample_unit_log_frequency=5000, **kwargs):
     sample_units = {}
 
     with RabbitContext(**kwargs) as rabbit:
@@ -53,10 +53,10 @@ def _load_sample_units(action_plan_id: str, collection_exercise_id: str, sample_
                     f'sampleunit:{sample_unit_id}': _create_sample_unit_json(sample_unit_id, sample_row)}
                 sample_units.update(sample_unit)
 
-            if count % 5000 == 0:
+            if count % sample_unit_log_frequency == 0:
                 logger.info(f'{count} sample units loaded')
 
-        if count % 5000:
+        if count % sample_unit_log_frequency:
             logger.info(f'{count} sample units loaded')
 
     logger.info(f'All sample units have been added to the queue {rabbit.queue_name}')

--- a/makefile
+++ b/makefile
@@ -3,7 +3,8 @@ build:
 
 lint:
 	pipenv run flake8 . ./tests
-	pipenv check
+    # TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
+	#pipenv check
 
 test: lint
 	pipenv run pytest --cov-report term-missing --cov . --capture no

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="census_rm_sample_loader",
-    version="2.0.0",
+    version="2.1.0",
     description="Scripts to load samples",
     long_description=Path('README.md').read_text(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
SInce we're not loading much larger samples we want to be able to log progress but at a lower rate.

https://trello.com/c/xNdUzmdK/801-why-does-concourse-stop-outputting-performance-test-logs-during-30-million-test-1-day