### PR TITLE
To make sample generate to start printbatch from zero

### DIFF
--- a/generate_sample_file.py
+++ b/generate_sample_file.py
@@ -111,7 +111,7 @@ class SampleGenerator:
 
     @staticmethod
     def get_random_print_batch():
-        print_batch = random.randint(1, 99)
+        print_batch = random.randint(0, 99)
         return print_batch
 
     def get_random_estab_type(self):


### PR DESCRIPTION
Motivation and Context
To change the sample generator to start generating from print batch from 0

What has changed
samplegenerator will now start generating case from Printbatch 0

How to test?
Run sample generator and make sure the sample file generated have cases starting with printbatch '0'

Links
https://trello.com/c/6A8bwcof/1362-update-sample-file-generator-to-generate-printbatch-0-cases