### PR TITLE
Handle malformed decimal lat long values

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -111,6 +111,14 @@ class TestValidators(TestCase):
 
         # Then no invalid exception is raised
 
+    def test_lat_long_malformed_decimal(self):
+        # Given
+        lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
+
+        # When, then raises
+        with pytest.raises(validators.Invalid):
+            lat_long_validator('1')
+
     def test_lat_long_invalid_format(self):
         # Given
         lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)

--- a/validators.py
+++ b/validators.py
@@ -48,7 +48,10 @@ def latitude_longitude(max_precision: int, max_scale: int):
             float(value)
         except ValueError:
             raise Invalid(f'Value "{value}" is not a valid float')
-        integer, decimal = value.split('.')
+        try:
+            integer, decimal = value.split('.')
+        except ValueError:
+            raise Invalid(f'Malformed decimal, Value = "{value}"')
         integer = integer.strip('-')
         scale = len(decimal)
         precision = len(integer) + len(decimal)


### PR DESCRIPTION
# Motivation and Context
The script would exception and die if it got a numeric but not well formed decimal value lat/long. It should properly record them as validation failures.

# What has changed
*  Handle malformed decimal lat long values

# How to test?
Check the test, run a sample file with malformed lat longs.

# Links
https://trello.com/c/j3XcUYyF/1564-handle-malformed-decimals-in-sample-validators