### PR TITLE
Write a fancy-pants sample redactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ requirements.txt
 .screenshots
 
 sample_file.csv
+
+sample_files/

--- a/generate_sample_file.py
+++ b/generate_sample_file.py
@@ -13,6 +13,8 @@ class SampleGenerator:
     COUNTRIES = ['E', 'W', 'N']
     ROADS = ['Road', 'Street', 'Lane', 'Passage', 'Alley', 'Way', 'Avenue']
     CONURBATIONS = ['City', 'Town', 'Village', 'Hamlet']
+    AREA_SUFFIXES = ['mere', 'ham', 'stead', 'on']
+    TOWN_SUFFIXES = ['ville', 'ford', 'ing', 'cester', 'mouth', 'bury', 'by']
     LETTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
                'V', 'W', 'X', 'Y', 'Z']
     WORDS = []
@@ -92,6 +94,26 @@ class SampleGenerator:
         random_road = self.ROADS[random.randint(0, len(self.ROADS) - 1)]
 
         return f'{random_number} {self.get_random_word()} {self.get_random_word()} {random_road}'
+
+    def _get_random_address_line_2_or_3(self, line_number: int):
+        random_suffix = self.AREA_SUFFIXES[random.randint(0, len(self.AREA_SUFFIXES) - 1)]
+        if line_number == 3:
+            random_suffix = self.TOWN_SUFFIXES[random.randint(0, len(self.TOWN_SUFFIXES) - 1)]
+        random_word = self.get_random_word()
+        address_line = f'{random_word}{random_suffix}'
+        if random_word.endswith(random_suffix):
+            address_line = random_word
+        return address_line
+
+    def get_random_address_lines_2_and_3(self):
+        number_of_address_lines = random.randint(1, 3)
+        address_line_2 = ''
+        address_line_3 = ''
+        if number_of_address_lines >= 2:
+            address_line_2 = self._get_random_address_line_2_or_3(line_number=2)
+            if number_of_address_lines == 3:
+                address_line_3 = self._get_random_address_line_2_or_3(line_number=3)
+        return [address_line_2, address_line_3]
 
     def get_random_post_town(self):
         random_conurbation = self.CONURBATIONS[random.randint(0, len(self.CONURBATIONS) - 1)]
@@ -187,6 +209,8 @@ class SampleGenerator:
         if estab_uprn is None:
             estab_uprn = self.get_random_uprn()
 
+        address_line_2, address_line_3 = self.get_random_address_lines_2_and_3()
+
         writer.writerow({
             'UPRN': uprn,
             'ESTAB_UPRN': estab_uprn,
@@ -196,8 +220,8 @@ class SampleGenerator:
             'ABP_CODE': self.get_random_abp_code(),
             'ORGANISATION_NAME': '',
             'ADDRESS_LINE1': self.get_random_address_line(),
-            'ADDRESS_LINE2': '',
-            'ADDRESS_LINE3': '',
+            'ADDRESS_LINE2': address_line_2,
+            'ADDRESS_LINE3': address_line_3,
             'TOWN_NAME': self.get_random_post_town(),
             'POSTCODE': self.get_random_post_code(),
             'LATITUDE': self.get_random_lat_or_long(),

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -10,12 +10,12 @@ from generate_sample_file import SampleGenerator
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 SampleGen = SampleGenerator()
-sensitive_estab_types = ['MILITARY US SFA', 'MILITARY SFA', 'MILITARY US SLA', 'ROYAL HOUSEHOLD',
+SENSITIVE_ESTAB_TYPES = ['MILITARY US SFA', 'MILITARY SFA', 'MILITARY US SLA', 'ROYAL HOUSEHOLD',
                          'MOD HOUSEHOLDS', 'HIGH SECURE MENTAL HEALTH', 'ROUGH SLEEPER', 'TRANSIENT PERSONS',
                          'TRAVELLING PERSONS', 'GRT SITE', 'MIGRANT WORKERS', 'IMMIGRATION REMOVAL CENTRE',
                          'SHELTERED ACCOMMODATION', 'APPROVED PREMISES', 'RESIDENTIAL CHILDRENS HOME',
                          'RELIGIOUS COMMUNITY', 'LOW/MEDIUM SECURE MENTAL HEALTH', 'BOARDING SCHOOL']
-non_sensitive_estab_types = [estab for estab in SampleGen.ESTAB_TYPES if estab not in sensitive_estab_types]
+non_sensitive_estab_types = [estab for estab in SampleGen.ESTAB_TYPES if estab not in SENSITIVE_ESTAB_TYPES]
 SampleGen.ESTAB_TYPES = non_sensitive_estab_types
 SampleGen.read_words()
 
@@ -57,7 +57,7 @@ def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: st
 def _redact_sample_row(sample_row: dict):
     sample_row['HTC_WILLINGNESS'] = SampleGen.get_random_htc()
     sample_row['HTC_DIGITAL'] = SampleGen.get_random_htc()
-    if sample_row['ESTAB_TYPE'] in sensitive_estab_types:
+    if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES:
         sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
         sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
         address_line_2, address_line_3 = SampleGen.get_random_address_lines_2_and_3()

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -37,7 +37,7 @@ def redact_sample(sample_file: Iterable[str], output_file_path):
 
 def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path,
                          sample_unit_log_frequency=50000):
-    logger.info(f'Redacting sample...')
+    logger.info('Redacting sample...')
 
     with open(output_file_path, 'w', newline='') as output_file:
         writer = csv.DictWriter(output_file, fieldnames=SampleGenerator.FIELDNAMES)
@@ -50,7 +50,7 @@ def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path,
             if count % sample_unit_log_frequency == 0:
                 logger.info(f'{count} sample units redacted')
 
-    logger.info(f'All sample units have been redacted')
+    logger.info('All sample units have been redacted')
 
 
 def _redact_sample_row(sample_row):

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -5,14 +5,17 @@ import os
 import sys
 from typing import Iterable
 
+from generate_sample_file import SampleGenerator
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-
-FIELDNAMES = ('UPRN', 'ESTAB_UPRN', 'ADDRESS_TYPE', 'ESTAB_TYPE', 'ADDRESS_LEVEL', 'ABP_CODE',
-              'ORGANISATION_NAME', 'ADDRESS_LINE1', 'ADDRESS_LINE2', 'ADDRESS_LINE3',
-              'TOWN_NAME', 'POSTCODE', 'LATITUDE', 'LONGITUDE', 'OA', 'LSOA',
-              'MSOA', 'LAD', 'REGION', 'HTC_WILLINGNESS', 'HTC_DIGITAL', 'TREATMENT_CODE',
-              'FIELDCOORDINATOR_ID', 'FIELDOFFICER_ID', 'CE_EXPECTED_CAPACITY', 'CE_SECURE', 'PRINT_BATCH')
+SampleGen = SampleGenerator()
+SampleGen.ESTAB_TYPES = ['HALL OF RESIDENCE', 'CARE HOME', 'HOSPITAL', 'HOSPICE', 'MENTAL HEALTH HOSPITAL',
+                         'MEDICAL CARE OTHER', 'BOARDING SCHOOL', 'HOTEL',
+                         'YOUTH HOSTEL', 'HOSTEL', 'EDUCATION OTHER', 'PRISON', 'STAFF ACCOMMODATION', 'CAMPHILL',
+                         'HOLIDAY PARK', 'HOUSEHOLD', 'RESIDENTIAL CARAVAN', 'RESIDENTIAL BOAT', 'GATED APARTMENTS',
+                         'FOREIGN OFFICES', 'CASTLES', 'EMBASSY', 'CARAVAN', 'MARINA']
+SampleGen.read_words()
 
 
 def parse_arguments():
@@ -21,61 +24,84 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def redact_sample_file(sample_file_path):
+def redact_sample_file(sample_file_path, output_file_path):
     with open(sample_file_path) as sample_file:
-        redact_sample(sample_file)
+        redact_sample(sample_file, output_file_path)
+    sample_file.close()
 
 
-def redact_sample(sample_file: Iterable[str]):
+def redact_sample(sample_file: Iterable[str], output_file_path):
     sample_file_reader = csv.DictReader(sample_file, delimiter=',')
-    _redact_sample_units(sample_file_reader)
+    _redact_sample_units(sample_file_reader, output_file_path)
 
 
-def _redact_sample_units(sample_file_reader: Iterable[str],
-                       sample_unit_log_frequency=5000):
+def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path,
+                         sample_unit_log_frequency=50000):
     logger.info(f'Redacting sample...')
 
-    with open("redacted_sample.csv", 'w', newline='') as output_file:
-        writer = csv.DictWriter(output_file, fieldnames=FIELDNAMES)
+    with open(output_file_path, 'w', newline='') as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=SampleGenerator.FIELDNAMES)
         writer.writeheader()
 
         for count, sample_row in enumerate(sample_file_reader, 1):
-            writer.writerow({
-                'UPRN': sample_row['UPRN'],
-                'ESTAB_UPRN': sample_row['ESTAB_UPRN'],
-                'ADDRESS_TYPE': sample_row['ADDRESS_TYPE'],
-                'ESTAB_TYPE': sample_row['ESTAB_TYPE'],
-                'ADDRESS_LEVEL': sample_row['ADDRESS_LEVEL'],
-                'ABP_CODE': sample_row['ABP_CODE'],
-                'ORGANISATION_NAME': 'Acme Widget Company',
-                'ADDRESS_LINE1': "123 fake street",
-                'ADDRESS_LINE2': 'Banana sausage',
-                'ADDRESS_LINE3': 'Frugal penny',
-                'TOWN_NAME': "Flibbleville",
-                'POSTCODE': "AB1 2XY",
-                'LATITUDE': "12.3",
-                'LONGITUDE': "50.60",
-                'OA': sample_row['OA'],
-                'LSOA': sample_row['LSOA'],
-                'MSOA': sample_row['MSOA'],
-                'LAD': sample_row['LAD'],
-                'REGION': sample_row['REGION'],
-                'HTC_WILLINGNESS': "1",
-                'HTC_DIGITAL': "1",
-                'TREATMENT_CODE': sample_row['TREATMENT_CODE'],
-                'FIELDCOORDINATOR_ID': sample_row['FIELDCOORDINATOR_ID'],
-                'FIELDOFFICER_ID': sample_row['FIELDOFFICER_ID'],
-                'CE_EXPECTED_CAPACITY': sample_row['CE_EXPECTED_CAPACITY'],
-                'CE_SECURE': sample_row['CE_SECURE'],
-                'PRINT_BATCH': sample_row['PRINT_BATCH']})
+            redacted_sample_row = _redact_sample_row(sample_row)
+            _write_row(writer, redacted_sample_row)
 
-        if count % sample_unit_log_frequency == 0:
-            logger.info(f'{count} sample units redacted')
-
-    if count % sample_unit_log_frequency:
-        logger.info(f'{count} sample units redacted')
+            if count % sample_unit_log_frequency == 0:
+                logger.info(f'{count} sample units redacted')
 
     logger.info(f'All sample units have been redacted')
+
+
+def _redact_sample_row(sample_row):
+    sample_row['HTC_WILLINGNESS'] = SampleGen.get_random_htc()
+    sample_row['HTC_DIGITAL'] = SampleGen.get_random_htc()
+    if sample_row['ESTAB_TYPE'] in ['MILITARY US SFA', 'MILITARY SFA', 'MILITARY US SLA', 'ROYAL HOUSEHOLD',
+                                    'MOD HOUSEHOLDS', 'HIGH SECURE MENTAL HEALTH', 'ROUGH SLEEPER', 'TRANSIENT PERSONS',
+                                    'TRAVELLING PERSONS', 'GRT SITE', 'MIGRANT WORKERS', 'IMMIGRATION REMOVAL CENTRE',
+                                    'SHELTERED ACCOMMODATION', 'APPROVED PREMISES', 'RESIDENTIAL CHILDRENS HOME',
+                                    'RELIGIOUS COMMUNITY', 'LOW/MEDIUM SECURE MENTAL HEALTH']:
+        sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
+        sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
+        sample_row['ADDRESS_LINE2'] = ''
+        sample_row['ADDRESS_LINE3'] = ''
+        sample_row['TOWN_NAME'] = SampleGen.get_random_post_town()
+        sample_row['POSTCODE'] = SampleGen.get_random_post_code()
+        sample_row['LATITUDE'] = SampleGen.get_random_lat_or_long()
+        sample_row['LONGITUDE'] = SampleGen.get_random_lat_or_long()
+
+    return sample_row
+
+
+def _write_row(writer, sample_row):
+    writer.writerow({
+        'UPRN': sample_row['UPRN'],
+        'ESTAB_UPRN': sample_row['ESTAB_UPRN'],
+        'ADDRESS_TYPE': sample_row['ADDRESS_TYPE'],
+        'ESTAB_TYPE': sample_row['ESTAB_TYPE'],
+        'ADDRESS_LEVEL': sample_row['ADDRESS_LEVEL'],
+        'ABP_CODE': sample_row['ABP_CODE'],
+        'ORGANISATION_NAME': sample_row['ORGANISATION_NAME'],
+        'ADDRESS_LINE1': sample_row['ADDRESS_LINE1'],
+        'ADDRESS_LINE2': sample_row['ADDRESS_LINE2'],
+        'ADDRESS_LINE3': sample_row['ADDRESS_LINE3'],
+        'TOWN_NAME': sample_row['TOWN_NAME'],
+        'POSTCODE': sample_row['POSTCODE'],
+        'LATITUDE': sample_row['LATITUDE'],
+        'LONGITUDE': sample_row['LONGITUDE'],
+        'OA': sample_row['OA'],
+        'LSOA': sample_row['LSOA'],
+        'MSOA': sample_row['MSOA'],
+        'LAD': sample_row['LAD'],
+        'REGION': sample_row['REGION'],
+        'HTC_WILLINGNESS': sample_row['HTC_WILLINGNESS'],
+        'HTC_DIGITAL': sample_row['HTC_DIGITAL'],
+        'TREATMENT_CODE': sample_row['TREATMENT_CODE'],
+        'FIELDCOORDINATOR_ID': sample_row['FIELDCOORDINATOR_ID'],
+        'FIELDOFFICER_ID': sample_row['FIELDOFFICER_ID'],
+        'CE_EXPECTED_CAPACITY': sample_row['CE_EXPECTED_CAPACITY'],
+        'CE_SECURE': sample_row['CE_SECURE'],
+        'PRINT_BATCH': sample_row['PRINT_BATCH']})
 
 
 def main():
@@ -83,7 +109,8 @@ def main():
     logging.basicConfig(handlers=[logging.StreamHandler(sys.stdout)], level=log_level or logging.ERROR)
     logger.setLevel(log_level or logging.INFO)
     args = parse_arguments()
-    redact_sample_file(args.sample_file_path)
+    output_file_path = 'sample_files/' + args.sample_file_path.split('/')[-1].split('.csv')[0] + '_redacted.csv'
+    redact_sample_file(args.sample_file_path, output_file_path)
 
 
 if __name__ == "__main__":

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -1,0 +1,90 @@
+import argparse
+import csv
+import logging
+import os
+import sys
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+FIELDNAMES = ('UPRN', 'ESTAB_UPRN', 'ADDRESS_TYPE', 'ESTAB_TYPE', 'ADDRESS_LEVEL', 'ABP_CODE',
+              'ORGANISATION_NAME', 'ADDRESS_LINE1', 'ADDRESS_LINE2', 'ADDRESS_LINE3',
+              'TOWN_NAME', 'POSTCODE', 'LATITUDE', 'LONGITUDE', 'OA', 'LSOA',
+              'MSOA', 'LAD', 'REGION', 'HTC_WILLINGNESS', 'HTC_DIGITAL', 'TREATMENT_CODE',
+              'FIELDCOORDINATOR_ID', 'FIELDOFFICER_ID', 'CE_EXPECTED_CAPACITY', 'CE_SECURE', 'PRINT_BATCH')
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Load a sample file into response management.')
+    parser.add_argument('sample_file_path', help='path to the sample file', type=str)
+    return parser.parse_args()
+
+
+def redact_sample_file(sample_file_path):
+    with open(sample_file_path) as sample_file:
+        redact_sample(sample_file)
+
+
+def redact_sample(sample_file: Iterable[str]):
+    sample_file_reader = csv.DictReader(sample_file, delimiter=',')
+    _redact_sample_units(sample_file_reader)
+
+
+def _redact_sample_units(sample_file_reader: Iterable[str],
+                       sample_unit_log_frequency=5000):
+    logger.info(f'Redacting sample...')
+
+    with open("redacted_sample.csv", 'w', newline='') as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=FIELDNAMES)
+        writer.writeheader()
+
+        for count, sample_row in enumerate(sample_file_reader, 1):
+            writer.writerow({
+                'UPRN': sample_row['UPRN'],
+                'ESTAB_UPRN': sample_row['ESTAB_UPRN'],
+                'ADDRESS_TYPE': sample_row['ADDRESS_TYPE'],
+                'ESTAB_TYPE': sample_row['ESTAB_TYPE'],
+                'ADDRESS_LEVEL': sample_row['ADDRESS_LEVEL'],
+                'ABP_CODE': sample_row['ABP_CODE'],
+                'ORGANISATION_NAME': 'Acme Widget Company',
+                'ADDRESS_LINE1': "123 fake street",
+                'ADDRESS_LINE2': 'Banana sausage',
+                'ADDRESS_LINE3': 'Frugal penny',
+                'TOWN_NAME': "Flibbleville",
+                'POSTCODE': "AB1 2XY",
+                'LATITUDE': "12.3",
+                'LONGITUDE': "50.60",
+                'OA': sample_row['OA'],
+                'LSOA': sample_row['LSOA'],
+                'MSOA': sample_row['MSOA'],
+                'LAD': sample_row['LAD'],
+                'REGION': sample_row['REGION'],
+                'HTC_WILLINGNESS': "1",
+                'HTC_DIGITAL': "1",
+                'TREATMENT_CODE': sample_row['TREATMENT_CODE'],
+                'FIELDCOORDINATOR_ID': sample_row['FIELDCOORDINATOR_ID'],
+                'FIELDOFFICER_ID': sample_row['FIELDOFFICER_ID'],
+                'CE_EXPECTED_CAPACITY': sample_row['CE_EXPECTED_CAPACITY'],
+                'CE_SECURE': sample_row['CE_SECURE'],
+                'PRINT_BATCH': sample_row['PRINT_BATCH']})
+
+        if count % sample_unit_log_frequency == 0:
+            logger.info(f'{count} sample units redacted')
+
+    if count % sample_unit_log_frequency:
+        logger.info(f'{count} sample units redacted')
+
+    logger.info(f'All sample units have been redacted')
+
+
+def main():
+    log_level = os.getenv('LOG_LEVEL')
+    logging.basicConfig(handlers=[logging.StreamHandler(sys.stdout)], level=log_level or logging.ERROR)
+    logger.setLevel(log_level or logging.INFO)
+    args = parse_arguments()
+    redact_sample_file(args.sample_file_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -56,7 +56,7 @@ class TestRedactSample(TestCase):
         # Given
         sample_dict_row = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
                            'ESTAB_TYPE': 'MILITARY SFA', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06',
-                           'ORGANISATION_NAME': '', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                           'ORGANISATION_NAME': 'An Organisation', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
                            'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': 'Another Address Line',
                            'TOWN_NAME': 'Windleybury',
                            'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421', 'LONGITUDE': '-2.5924477',
@@ -68,7 +68,7 @@ class TestRedactSample(TestCase):
 
         sample_dict_row_reference = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
                                      'ESTAB_TYPE': 'MILITARY SFA', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06',
-                                     'ORGANISATION_NAME': '', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                                     'ORGANISATION_NAME': 'An Organisation', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
                                      'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': 'Another Address Line',
                                      'TOWN_NAME': 'Windleybury', 'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421',
                                      'LONGITUDE': '-2.5924477', 'OA': 'E00073438', 'LSOA': 'E01014540',
@@ -97,3 +97,5 @@ class TestRedactSample(TestCase):
         self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE2'], redacted_sample_row['ADDRESS_LINE2'])
 
         self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE3'], redacted_sample_row['ADDRESS_LINE3'])
+
+        self.assertNotEqual(sample_dict_row_reference['ORGANISATION_NAME'], redacted_sample_row['ORGANISATION_NAME'])

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -1,0 +1,99 @@
+import shutil
+from pathlib import Path
+from unittest import TestCase
+
+import redact_sample
+from validate_sample import SampleValidator
+
+
+class TestRedactSample(TestCase):
+    RESOURCE_FILE_PATH = Path(__file__).parent.joinpath('resources')
+    TMP_TEST_DIRECTORY_PATH = RESOURCE_FILE_PATH.joinpath('sample_files')
+
+    def setUp(self) -> None:
+        shutil.rmtree(self.TMP_TEST_DIRECTORY_PATH, ignore_errors=True)
+        self.TMP_TEST_DIRECTORY_PATH.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.TMP_TEST_DIRECTORY_PATH, ignore_errors=True)
+
+    def test_redact_sample_valid_output(self):
+        # Given
+        sample_file_path = self.RESOURCE_FILE_PATH.joinpath('sample_file_1_per_treatment_code.csv')
+        sample_redacted_file_path = self.TMP_TEST_DIRECTORY_PATH.joinpath(
+            'sample_file_1_per_treatment_code_redacted.csv')
+
+        # When
+        redact_sample.redact_sample_file(sample_file_path, sample_redacted_file_path)
+        sample_validator = SampleValidator()
+        validation_failures = sample_validator.validate(sample_redacted_file_path)
+
+        # Then
+        self.assertEqual(validation_failures, [])
+
+    def test_redact_random_htc(self):
+        # Given
+        sample_dict_row = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
+                           'ESTAB_TYPE': 'HOUSEHOLD', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06', 'ORGANISATION_NAME': '',
+                           'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                           'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': '', 'TOWN_NAME': 'Windleybury',
+                           'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421', 'LONGITUDE': '-2.5924477',
+                           'OA': 'E00073438', 'LSOA': 'E01014540', 'MSOA': 'E02003043', 'LAD': 'E06000023',
+                           'REGION': 'E12000009', 'HTC_WILLINGNESS': '1',
+                           'HTC_DIGITAL': '5', 'FIELDCOORDINATOR_ID': '1', 'FIELDOFFICER_ID': '2',
+                           'TREATMENT_CODE': 'HH_LF3R2E', 'CE_EXPECTED_CAPACITY': '3', 'CE_SECURE': '0',
+                           'PRINT_BATCH': '2'}
+
+        # When
+        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row)
+
+        # Then
+        self.assertTrue(1 <= int(redacted_sample_row['HTC_WILLINGNESS']) <= 5)
+
+        self.assertTrue(1 <= int(redacted_sample_row['HTC_DIGITAL']) <= 5)
+
+    def test_redact_fields_sensitive_estab(self):
+        # Given
+        sample_dict_row = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
+                           'ESTAB_TYPE': 'MILITARY SFA', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06',
+                           'ORGANISATION_NAME': '', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                           'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': 'Another Address Line',
+                           'TOWN_NAME': 'Windleybury',
+                           'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421', 'LONGITUDE': '-2.5924477',
+                           'OA': 'E00073438', 'LSOA': 'E01014540', 'MSOA': 'E02003043', 'LAD': 'E06000023',
+                           'REGION': 'E12000009', 'HTC_WILLINGNESS': '1',
+                           'HTC_DIGITAL': '5', 'FIELDCOORDINATOR_ID': '1', 'FIELDOFFICER_ID': '2',
+                           'TREATMENT_CODE': 'HH_LF3R2E', 'CE_EXPECTED_CAPACITY': '3', 'CE_SECURE': '0',
+                           'PRINT_BATCH': '2'}
+
+        sample_dict_row_reference = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
+                                     'ESTAB_TYPE': 'MILITARY SFA', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06',
+                                     'ORGANISATION_NAME': '', 'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                                     'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': 'Another Address Line',
+                                     'TOWN_NAME': 'Windleybury', 'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421',
+                                     'LONGITUDE': '-2.5924477', 'OA': 'E00073438', 'LSOA': 'E01014540',
+                                     'MSOA': 'E02003043', 'LAD': 'E06000023', 'REGION': 'E12000009',
+                                     'HTC_WILLINGNESS': '1',
+                                     'HTC_DIGITAL': '5', 'FIELDCOORDINATOR_ID': '1', 'FIELDOFFICER_ID': '2',
+                                     'TREATMENT_CODE': 'HH_LF3R2E', 'CE_EXPECTED_CAPACITY': '3', 'CE_SECURE': '0',
+                                     'PRINT_BATCH': '2'}
+
+        # When
+        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row)
+
+        # Then
+        self.assertNotEqual(sample_dict_row_reference['ESTAB_TYPE'], redacted_sample_row['ESTAB_TYPE'])
+
+        self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE1'], redacted_sample_row['ADDRESS_LINE1'])
+
+        self.assertNotEqual(sample_dict_row_reference['TOWN_NAME'], redacted_sample_row['TOWN_NAME'])
+
+        self.assertNotEqual(sample_dict_row_reference['POSTCODE'], redacted_sample_row['POSTCODE'])
+
+        self.assertNotEqual(sample_dict_row_reference['LATITUDE'], redacted_sample_row['LATITUDE'])
+
+        self.assertNotEqual(sample_dict_row_reference['LONGITUDE'], redacted_sample_row['LONGITUDE'])
+
+        self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE2'], redacted_sample_row['ADDRESS_LINE2'])
+
+        self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE3'], redacted_sample_row['ADDRESS_LINE3'])


### PR DESCRIPTION
# Motivation and Context
Introducing sample redactor with randomised HTC values and redaction of addresses for sensitive estab types. For the purposes of redacting prod data.

# What has changed
Added python script redact_sample.py to do the redaction.
Added test_redact_sample.py with basic unit tests for redact_sample.py.
Added sample_files/ directory to .gitignore.
Added generation of address line 2 and 3 to sample generator and redactor.

# How to test?
Run test_redact_sample.py  unit test from within PyCharm.
If Running redact_sample.py locally, first create sample_files/ directory in the repository root.
Build Docker Image from repo, deploy built image in sample-loader pod from /optional, inside pod run:
pipenv run python redact_sample.py <sample_file_name>


# Links
https://trello.com/c/dw58G1iF