### PR TITLE
Fix validators empty region/treatment Index Error

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -230,6 +230,20 @@ class TestValidators(TestCase):
         with pytest.raises(validators.Invalid):
             region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': 'HH_TESTE'})
 
+    def test_region_matches_treatment_code_empty_region_no_error(self):
+        # Given
+        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+        # When, then doesn't error.
+        region_matches_treatment_code_validator(' ', row={'TREATMENT_CODE': 'HH_TESTE'})
+
+    def test_region_matches_treatment_code_empty_treatment_no_error(self):
+        # Given
+        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+        # When, then doesn't error.
+        region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': ' '})
+
     def test_ce_u_has_expected_capacity_valid(self):
         # Given
         ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()

--- a/validators.py
+++ b/validators.py
@@ -103,7 +103,8 @@ def no_pipe_character():
 
 def region_matches_treatment_code():
     def validate(region, **kwargs):
-        if region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
+        if region.strip() and kwargs['row']['TREATMENT_CODE'].strip() and \
+                region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
             raise Invalid(
                 f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
 


### PR DESCRIPTION
# Motivation and Context
Validators in sample-loader need to reflect code of validators in census-rm-toolbox: prevent treatment to region comparison causing an IndexError

# What has changed
Add conditional to check if treatment and region code exists.
Add two tests to cover this code.

# How to test?
Run tests in PyCharm or with make test

# Links
https://trello.com/c/RogOSjeh