### PR TITLE
1623- Optional redact HTC from sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@ To redact **all** sensitive fields, run it with the script :
 ```shell script
 pipenv run python redact_sample.py sample_files/my_sample.csv
 ```
+And it will write out the redacted file to `my_sample_redacted.csv`
 
 To redact just the HTC fields, run the script with the flag `--redact-htc-only`:
 ```shell script
 pipenv run python redact_sample.py sample_files/my_sample.csv --redact-htc-only
 ```
 
-And it will write out the generated file to `my_sample_redacted.csv` or `my_sample_htc_redacted_only.csv`
+And it will write out the redacted file to `my_sample_htc_redacted_only.csv`

--- a/README.md
+++ b/README.md
@@ -112,3 +112,18 @@ pipenv run python generate_sample_file.py -o /custom/path.csv -t /path/to/treatm
 Where the treatment code quantities file is a csv with headers `"Treatment Code"` and `"Quantity"` specifying the quantities of each treatment code to include in the generated sample
 
 An optional flag `-s` or `--sequential_uprn` can be used to generate unique UPRN's sequentially instead of randomly, making it faster to generate a massive file.
+
+## Sample file redactor
+The [`redact_sample.py`](/redact_sample.py) script takes in a sample file and outputs the same sample with random data for redacted fields
+
+To redact **all** sensitive fields, run it with the script :
+```shell script
+pipenv run python redact_sample.py sample_files/my_sample.csv
+```
+
+To redact just the HTC fields, run the script with the flag `--redact-htc-only`:
+```shell script
+pipenv run python redact_sample.py sample_files/my_sample.csv --redact-htc-only
+```
+
+And it will write out the generated file to `my_sample_redacted.csv` or `my_sample_htc_redacted_only.csv`

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -60,18 +60,17 @@ def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: Pa
 def _redact_sample_row(sample_row: dict, redact_htc_only: bool):
     sample_row['HTC_WILLINGNESS'] = SampleGen.get_random_htc()
     sample_row['HTC_DIGITAL'] = SampleGen.get_random_htc()
-    if not redact_htc_only:
+    if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES and not redact_htc_only:
+        sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
+        sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
+        address_line_2, address_line_3 = SampleGen.get_random_address_lines_2_and_3()
+        sample_row['ADDRESS_LINE2'] = address_line_2
+        sample_row['ADDRESS_LINE3'] = address_line_3
+        sample_row['TOWN_NAME'] = SampleGen.get_random_post_town()
+        sample_row['POSTCODE'] = SampleGen.get_random_post_code()
+        sample_row['LATITUDE'] = SampleGen.get_random_lat_or_long()
+        sample_row['LONGITUDE'] = SampleGen.get_random_lat_or_long()
         sample_row['ORGANISATION_NAME'] = ''
-        if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES:
-            sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
-            sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
-            address_line_2, address_line_3 = SampleGen.get_random_address_lines_2_and_3()
-            sample_row['ADDRESS_LINE2'] = address_line_2
-            sample_row['ADDRESS_LINE3'] = address_line_3
-            sample_row['TOWN_NAME'] = SampleGen.get_random_post_town()
-            sample_row['POSTCODE'] = SampleGen.get_random_post_code()
-            sample_row['LATITUDE'] = SampleGen.get_random_lat_or_long()
-            sample_row['LONGITUDE'] = SampleGen.get_random_lat_or_long()
     return sample_row
 
 

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -6,7 +6,6 @@ import sys
 from typing import Iterable
 from pathlib import Path
 
-
 from generate_sample_file import SampleGenerator
 
 logger = logging.getLogger(__name__)
@@ -31,17 +30,17 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def redact_sample_file(sample_file_path: int, output_file_path: str,  redact_htc_only: bool = False):
+def redact_sample_file(sample_file_path: int, output_file_path: Path,  redact_htc_only: bool):
     with open(sample_file_path) as sample_file:
         _redact_sample(sample_file, output_file_path, redact_htc_only)
 
 
-def _redact_sample(sample_file: Iterable[str], output_file_path: str, redact_htc_only: bool):
+def _redact_sample(sample_file: Iterable[str], output_file_path: Path, redact_htc_only: bool):
     sample_file_reader = csv.DictReader(sample_file, delimiter=',')
     _redact_sample_units(sample_file_reader, output_file_path, redact_htc_only)
 
 
-def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: str, redact_htc_only):
+def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: Path, redact_htc_only: bool):
     logger.info('Redacting sample...')
 
     with open(output_file_path, 'w', newline='') as output_file:

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -17,6 +17,7 @@ SENSITIVE_ESTAB_TYPES = ['MILITARY US SFA', 'MILITARY SFA', 'MILITARY US SLA', '
                          'SHELTERED ACCOMMODATION', 'APPROVED PREMISES', 'RESIDENTIAL CHILDRENS HOME',
                          'RELIGIOUS COMMUNITY', 'LOW/MEDIUM SECURE MENTAL HEALTH', 'BOARDING SCHOOL']
 SAMPLE_UNIT_LOG_FREQUENCY = 50000
+HTC_REDACTED_VALUE = 1
 NON_SENSITIVE_ESTAB_TYPES = [estab for estab in SampleGen.ESTAB_TYPES if estab not in SENSITIVE_ESTAB_TYPES]
 SampleGen.ESTAB_TYPES = NON_SENSITIVE_ESTAB_TYPES
 SampleGen.read_words()
@@ -58,8 +59,8 @@ def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: Pa
 
 
 def _redact_sample_row(sample_row: dict, redact_htc_only: bool):
-    sample_row['HTC_WILLINGNESS'] = SampleGen.get_random_htc()
-    sample_row['HTC_DIGITAL'] = SampleGen.get_random_htc()
+    sample_row['HTC_WILLINGNESS'] = HTC_REDACTED_VALUE
+    sample_row['HTC_DIGITAL'] = HTC_REDACTED_VALUE
     if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES and not redact_htc_only:
         sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
         sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()

--- a/redact_sample.py
+++ b/redact_sample.py
@@ -4,6 +4,8 @@ import logging
 import os
 import sys
 from typing import Iterable
+from pathlib import Path
+
 
 from generate_sample_file import SampleGenerator
 
@@ -15,29 +17,31 @@ SENSITIVE_ESTAB_TYPES = ['MILITARY US SFA', 'MILITARY SFA', 'MILITARY US SLA', '
                          'TRAVELLING PERSONS', 'GRT SITE', 'MIGRANT WORKERS', 'IMMIGRATION REMOVAL CENTRE',
                          'SHELTERED ACCOMMODATION', 'APPROVED PREMISES', 'RESIDENTIAL CHILDRENS HOME',
                          'RELIGIOUS COMMUNITY', 'LOW/MEDIUM SECURE MENTAL HEALTH', 'BOARDING SCHOOL']
-non_sensitive_estab_types = [estab for estab in SampleGen.ESTAB_TYPES if estab not in SENSITIVE_ESTAB_TYPES]
-SampleGen.ESTAB_TYPES = non_sensitive_estab_types
+SAMPLE_UNIT_LOG_FREQUENCY = 50000
+NON_SENSITIVE_ESTAB_TYPES = [estab for estab in SampleGen.ESTAB_TYPES if estab not in SENSITIVE_ESTAB_TYPES]
+SampleGen.ESTAB_TYPES = NON_SENSITIVE_ESTAB_TYPES
 SampleGen.read_words()
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Redact a sample file.')
     parser.add_argument('sample_file_path', help='path to the sample file', type=str)
+    parser.add_argument('--redact-htc-only', help="redact HTC values only", default=False, action='store_true',
+                        required=False)
     return parser.parse_args()
 
 
-def redact_sample_file(sample_file_path: int, output_file_path: str):
+def redact_sample_file(sample_file_path: int, output_file_path: str,  redact_htc_only: bool = False):
     with open(sample_file_path) as sample_file:
-        _redact_sample(sample_file, output_file_path)
+        _redact_sample(sample_file, output_file_path, redact_htc_only)
 
 
-def _redact_sample(sample_file: Iterable[str], output_file_path: str):
+def _redact_sample(sample_file: Iterable[str], output_file_path: str, redact_htc_only: bool):
     sample_file_reader = csv.DictReader(sample_file, delimiter=',')
-    _redact_sample_units(sample_file_reader, output_file_path)
+    _redact_sample_units(sample_file_reader, output_file_path, redact_htc_only)
 
 
-def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: str,
-                         sample_unit_log_frequency=50000):
+def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: str, redact_htc_only):
     logger.info('Redacting sample...')
 
     with open(output_file_path, 'w', newline='') as output_file:
@@ -45,29 +49,30 @@ def _redact_sample_units(sample_file_reader: Iterable[str], output_file_path: st
         writer.writeheader()
 
         for count, sample_row in enumerate(sample_file_reader, 1):
-            redacted_sample_row = _redact_sample_row(sample_row)
+            redacted_sample_row = _redact_sample_row(sample_row, redact_htc_only)
             _write_row(writer, redacted_sample_row)
 
-            if count % sample_unit_log_frequency == 0:
+            if count % SAMPLE_UNIT_LOG_FREQUENCY == 0:
                 logger.info(f'{count} sample units redacted')
 
     logger.info('All sample units have been redacted')
 
 
-def _redact_sample_row(sample_row: dict):
+def _redact_sample_row(sample_row: dict, redact_htc_only: bool):
     sample_row['HTC_WILLINGNESS'] = SampleGen.get_random_htc()
     sample_row['HTC_DIGITAL'] = SampleGen.get_random_htc()
-    if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES:
-        sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
-        sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
-        address_line_2, address_line_3 = SampleGen.get_random_address_lines_2_and_3()
-        sample_row['ADDRESS_LINE2'] = address_line_2
-        sample_row['ADDRESS_LINE3'] = address_line_3
-        sample_row['TOWN_NAME'] = SampleGen.get_random_post_town()
-        sample_row['POSTCODE'] = SampleGen.get_random_post_code()
-        sample_row['LATITUDE'] = SampleGen.get_random_lat_or_long()
-        sample_row['LONGITUDE'] = SampleGen.get_random_lat_or_long()
+    if not redact_htc_only:
         sample_row['ORGANISATION_NAME'] = ''
+        if sample_row['ESTAB_TYPE'] in SENSITIVE_ESTAB_TYPES:
+            sample_row['ESTAB_TYPE'] = SampleGen.get_random_estab_type()
+            sample_row['ADDRESS_LINE1'] = SampleGen.get_random_address_line()
+            address_line_2, address_line_3 = SampleGen.get_random_address_lines_2_and_3()
+            sample_row['ADDRESS_LINE2'] = address_line_2
+            sample_row['ADDRESS_LINE3'] = address_line_3
+            sample_row['TOWN_NAME'] = SampleGen.get_random_post_town()
+            sample_row['POSTCODE'] = SampleGen.get_random_post_code()
+            sample_row['LATITUDE'] = SampleGen.get_random_lat_or_long()
+            sample_row['LONGITUDE'] = SampleGen.get_random_lat_or_long()
     return sample_row
 
 
@@ -102,8 +107,10 @@ def _write_row(writer: csv.DictWriter, sample_row: dict):
         'PRINT_BATCH': sample_row['PRINT_BATCH']})
 
 
-def create_output_path(sample_file_path: str):
-    output_file_path = 'sample_files/' + sample_file_path.split('/')[-1].split('.csv')[0] + '_redacted.csv'
+def create_output_path(sample_file_path: Path, redact_htc_only: bool) -> Path:
+    file_name_suffix = '_redacted.csv' if not redact_htc_only else '_redacted_htc_only.csv'
+    redacted_file_name = f'{Path(sample_file_path).stem}{file_name_suffix}'
+    output_file_path = Path('sample_files').joinpath(redacted_file_name)
     return output_file_path
 
 
@@ -112,8 +119,8 @@ def main():
     logging.basicConfig(handlers=[logging.StreamHandler(sys.stdout)], level=log_level or logging.ERROR)
     logger.setLevel(log_level or logging.INFO)
     args = parse_arguments()
-    output_file_path = create_output_path(args.sample_file_path)
-    redact_sample_file(args.sample_file_path, output_file_path)
+    output_file_path = create_output_path(args.sample_file_path, args.redact_htc_only)
+    redact_sample_file(args.sample_file_path, output_file_path, args.redact_htc_only)
 
 
 if __name__ == "__main__":

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -82,7 +82,6 @@ class TestRedactSample(TestCase):
         self.assertEqual(sample_dict_row['ADDRESS_LINE3'], redacted_sample_row['ADDRESS_LINE3'])
         self.assertEqual(sample_dict_row['ORGANISATION_NAME'], redacted_sample_row['ORGANISATION_NAME'])
 
-
     def test_redact_fields_sensitive_estab(self):
         # Given
         sample_dict_row = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -45,12 +45,43 @@ class TestRedactSample(TestCase):
                            'PRINT_BATCH': '2'}
 
         # When
-        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row)
+        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row, redact_htc_only=False)
 
         # Then
         self.assertTrue(1 <= int(redacted_sample_row['HTC_WILLINGNESS']) <= 5)
 
         self.assertTrue(1 <= int(redacted_sample_row['HTC_DIGITAL']) <= 5)
+
+    def test_redact_htc_only(self):
+        # Given
+        sample_dict_row = {'UPRN': '10008677190', 'ESTAB_UPRN': '10008677194', 'ADDRESS_TYPE': 'HH',
+                           'ESTAB_TYPE': 'HOUSEHOLD', 'ADDRESS_LEVEL': 'U', 'ABP_CODE': 'RD06', 'ORGANISATION_NAME': '',
+                           'ADDRESS_LINE1': 'Flat 56 Francombe House',
+                           'ADDRESS_LINE2': 'Commercial Road', 'ADDRESS_LINE3': '', 'TOWN_NAME': 'Windleybury',
+                           'POSTCODE': 'XX1 0XX', 'LATITUDE': '51.4463421', 'LONGITUDE': '-2.5924477',
+                           'OA': 'E00073438', 'LSOA': 'E01014540', 'MSOA': 'E02003043', 'LAD': 'E06000023',
+                           'REGION': 'E12000009', 'HTC_WILLINGNESS': '1',
+                           'HTC_DIGITAL': '5', 'FIELDCOORDINATOR_ID': '1', 'FIELDOFFICER_ID': '2',
+                           'TREATMENT_CODE': 'HH_LF3R2E', 'CE_EXPECTED_CAPACITY': '3', 'CE_SECURE': '0',
+                           'PRINT_BATCH': '2'}
+
+        # When
+        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row, redact_htc_only=True)
+
+        # Then
+        self.assertTrue(1 <= int(redacted_sample_row['HTC_WILLINGNESS']) <= 5)
+        self.assertTrue(1 <= int(redacted_sample_row['HTC_DIGITAL']) <= 5)
+
+        self.assertEqual(sample_dict_row['ESTAB_TYPE'], redacted_sample_row['ESTAB_TYPE'])
+        self.assertEqual(sample_dict_row['ADDRESS_LINE1'], redacted_sample_row['ADDRESS_LINE1'])
+        self.assertEqual(sample_dict_row['TOWN_NAME'], redacted_sample_row['TOWN_NAME'])
+        self.assertEqual(sample_dict_row['POSTCODE'], redacted_sample_row['POSTCODE'])
+        self.assertEqual(sample_dict_row['LATITUDE'], redacted_sample_row['LATITUDE'])
+        self.assertEqual(sample_dict_row['LONGITUDE'], redacted_sample_row['LONGITUDE'])
+        self.assertEqual(sample_dict_row['ADDRESS_LINE2'], redacted_sample_row['ADDRESS_LINE2'])
+        self.assertEqual(sample_dict_row['ADDRESS_LINE3'], redacted_sample_row['ADDRESS_LINE3'])
+        self.assertEqual(sample_dict_row['ORGANISATION_NAME'], redacted_sample_row['ORGANISATION_NAME'])
+
 
     def test_redact_fields_sensitive_estab(self):
         # Given
@@ -79,7 +110,7 @@ class TestRedactSample(TestCase):
                                      'PRINT_BATCH': '2'}
 
         # When
-        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row)
+        redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row, redact_htc_only=False)
 
         # Then
         self.assertNotEqual(sample_dict_row_reference['ESTAB_TYPE'], redacted_sample_row['ESTAB_TYPE'])

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -48,9 +48,8 @@ class TestRedactSample(TestCase):
         redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row, redact_htc_only=False)
 
         # Then
-        self.assertTrue(1 <= int(redacted_sample_row['HTC_WILLINGNESS']) <= 5)
-
-        self.assertTrue(1 <= int(redacted_sample_row['HTC_DIGITAL']) <= 5)
+        self.assertEqual(1, redacted_sample_row['HTC_WILLINGNESS'])
+        self.assertEqual(1, redacted_sample_row['HTC_DIGITAL'])
 
     def test_redact_htc_only(self):
         # Given
@@ -69,8 +68,8 @@ class TestRedactSample(TestCase):
         redacted_sample_row = redact_sample._redact_sample_row(sample_dict_row, redact_htc_only=True)
 
         # Then
-        self.assertTrue(1 <= int(redacted_sample_row['HTC_WILLINGNESS']) <= 5)
-        self.assertTrue(1 <= int(redacted_sample_row['HTC_DIGITAL']) <= 5)
+        self.assertEqual(1, redacted_sample_row['HTC_WILLINGNESS'])
+        self.assertEqual(1, redacted_sample_row['HTC_DIGITAL'])
 
         self.assertEqual(sample_dict_row['ESTAB_TYPE'], redacted_sample_row['ESTAB_TYPE'])
         self.assertEqual(sample_dict_row['ADDRESS_LINE1'], redacted_sample_row['ADDRESS_LINE1'])
@@ -129,3 +128,23 @@ class TestRedactSample(TestCase):
         self.assertNotEqual(sample_dict_row_reference['ADDRESS_LINE3'], redacted_sample_row['ADDRESS_LINE3'])
 
         self.assertNotEqual(sample_dict_row_reference['ORGANISATION_NAME'], redacted_sample_row['ORGANISATION_NAME'])
+
+    def test_redacted_file_output_path(self):
+        # Given
+        file_path = Path('sample_files/test.csv')
+
+        # When
+        output_path = redact_sample.create_output_path(file_path, redact_htc_only=False)
+
+        # Then
+        self.assertEqual(Path('sample_files/test_redacted.csv'), output_path)
+
+    def test_redacted_file_output_path_htc_only(self):
+        # Given
+        file_path = Path('sample_files/test.csv')
+
+        # When
+        output_path = redact_sample.create_output_path(file_path, redact_htc_only=True)
+
+        # Then
+        self.assertEqual(Path('sample_files/test_redacted_htc_only.csv'), output_path)

--- a/tests/test_redact_sample.py
+++ b/tests/test_redact_sample.py
@@ -24,7 +24,7 @@ class TestRedactSample(TestCase):
             'sample_file_1_per_treatment_code_redacted.csv')
 
         # When
-        redact_sample.redact_sample_file(sample_file_path, sample_redacted_file_path)
+        redact_sample.redact_sample_file(sample_file_path, sample_redacted_file_path, redact_htc_only=False)
         sample_validator = SampleValidator()
         validation_failures = sample_validator.validate(sample_redacted_file_path)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to be able to redact a sample file just on the HTC counts.

# What has changed
<!--- What manifest changes have been made? -->
Updated script to include optional flag `--redact-htc-only`

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Put a sample file in a folder `sample_files`
Run the script with `--redact-htc-only` - check fields are changed as expected
Run the script without the flag - check all sensitive fields are still redacted

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/3bOvxQ56/1623-sample-redactor-optional-redact-htc-counts-only-3