### PR TITLE
Enforce lat longs in the format integer, decimal point, integer

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -132,7 +132,8 @@ def test_lat_long_valid():
     '1.2345*10**-3',
     '1.2345x10**-3',
     '1.2345x10^-3',
-    'eggs'
+    'eggs',
+    '12.34.56.789',
 ])
 def test_lat_long_scientific_notation_invalid(value):
     # Given

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,332 +1,389 @@
-from unittest import TestCase
-
 import pytest
 
 import validators
 
 
-class TestValidators(TestCase):
+def test_max_length_valid():
+    # Given
+    max_length_validator = validators.max_length(10)
 
-    def test_max_length_valid(self):
-        # Given
-        max_length_validator = validators.max_length(10)
+    # When
+    max_length_validator('a' * 9)
 
-        # When
-        max_length_validator('a' * 9)
+    # Then no invalid exception is raised
 
-        # Then no invalid exception is raised
 
-    def test_max_length_invalid(self):
-        # Given
-        max_length_0_validator = validators.max_length(10)
+def test_max_length_invalid():
+    # Given
+    max_length_0_validator = validators.max_length(10)
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            max_length_0_validator('a' * 11)
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        max_length_0_validator('a' * 11)
 
-    def test_unique_valid(self):
-        # Given
-        unique_validator = validators.unique()
 
-        # When
+def test_unique_valid():
+    # Given
+    unique_validator = validators.unique()
+
+    # When
+    unique_validator('1')
+    unique_validator('2')
+    unique_validator('3')
+    unique_validator('foo')
+    unique_validator('bar')
+
+    # Then no invalid exception is raised
+
+
+def test_unique_invalid():
+    # Given
+    unique_validator = validators.unique()
+
+    # When
+    unique_validator('1')
+    unique_validator('2')
+    unique_validator('3')
+    unique_validator('foo')
+
+    # Then raises
+    with pytest.raises(validators.Invalid):
         unique_validator('1')
-        unique_validator('2')
-        unique_validator('3')
-        unique_validator('foo')
-        unique_validator('bar')
 
-        # Then no invalid exception is raised
 
-    def test_unique_invalid(self):
-        # Given
-        unique_validator = validators.unique()
+def test_unique_validators_do_not_cross_validate():
+    # Given
+    unique_validator_1 = validators.unique()
+    unique_validator_2 = validators.unique()
 
-        # When
-        unique_validator('1')
-        unique_validator('2')
-        unique_validator('3')
-        unique_validator('foo')
+    # When
+    unique_validator_1('a')
+    unique_validator_2('a')
 
-        # Then raises
-        with pytest.raises(validators.Invalid):
-            unique_validator('1')
+    # Then no invalid exception is raised
 
-    def test_unique_validators_do_not_cross_validate(self):
-        # Given
-        unique_validator_1 = validators.unique()
-        unique_validator_2 = validators.unique()
 
-        # When
-        unique_validator_1('a')
-        unique_validator_2('a')
+def test_mandatory_valid():
+    # Given
+    mandatory_validator = validators.mandatory()
 
-        # Then no invalid exception is raised
+    # When
+    mandatory_validator('a')
 
-    def test_mandatory_valid(self):
-        # Given
-        mandatory_validator = validators.mandatory()
+    # Then no invalid exception is raised
 
-        # When
-        mandatory_validator('a')
 
-        # Then no invalid exception is raised
+def test_mandatory_invalid():
+    # Given
+    mandatory_validator = validators.mandatory()
 
-    def test_mandatory_invalid(self):
-        # Given
-        mandatory_validator = validators.mandatory()
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        mandatory_validator('')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            mandatory_validator('')
 
-    def test_numeric_valid(self):
-        # Given
-        numeric_validator = validators.numeric()
+def test_numeric_valid():
+    # Given
+    numeric_validator = validators.numeric()
 
-        # When
-        numeric_validator('0123456789')
+    # When
+    numeric_validator('0123456789')
 
-        # Then no invalid exception is raised
+    # Then no invalid exception is raised
 
-    def test_numeric_invalid(self):
-        # Given
-        numeric_validator = validators.numeric()
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            numeric_validator('a')
+def test_numeric_invalid():
+    # Given
+    numeric_validator = validators.numeric()
 
-        with pytest.raises(validators.Invalid):
-            numeric_validator('1.1')
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        numeric_validator('a')
 
-        with pytest.raises(validators.Invalid):
-            numeric_validator('_')
+    with pytest.raises(validators.Invalid):
+        numeric_validator('1.1')
 
-    def test_lat_long_valid(self):
-        # Given
-        lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
+    with pytest.raises(validators.Invalid):
+        numeric_validator('_')
 
-        # When
-        lat_long_validator('1234.5678')
 
-        # Then no invalid exception is raised
+def test_lat_long_valid():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-    def test_lat_long_malformed_decimal(self):
-        # Given
-        lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
+    # When
+    lat_long_validator('1234.5678')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            lat_long_validator('1')
+    # Then no invalid exception is raised
 
-    def test_lat_long_invalid_format(self):
-        # Given
-        lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            lat_long_validator('foo')
+@pytest.mark.parametrize('value', [
+    '1.1E-10',  # Python valid scientific notation
+    '1.1e-10',
+    '2e-4',
+    '2E-4',
+    '3E4',
+    '3e5',
+    '5.9238E-7',
+    '0.2E-3',
+    '23.4E-5',
+    '1.2345E2',
+    '1.2345*10^-3',  # Not python valid notation
+    '1.2345*10**-3',
+    '1.2345x10**-3',
+    '1.2345x10^-3',
+    'eggs'
+])
+def test_lat_long_scientific_notation_invalid(value):
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-    def test_lat_long_invalid_scale(self):
-        # Given
-        lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator(value)
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            lat_long_validator('1.567889')
 
-    def test_lat_long_invalid_precision(self):
-        # Given
-        lat_long_validator = validators.latitude_longitude(max_scale=10, max_precision=5)
+def test_lat_long_malformed_decimal():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            lat_long_validator('123456.7')
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator('1')
 
-    def test_in_set_valid(self):
-        # Given
-        in_set_validator = validators.in_set({'a', 'b', 'c'})
 
-        # When
-        in_set_validator('a')
-        in_set_validator('b')
-        in_set_validator('c')
+def test_lat_long_invalid_format():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-        # Then no invalid exception is raised
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator('foo')
 
-    def test_in_set_invalid(self):
-        # Given
-        in_set_validator = validators.in_set({'a'})
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            in_set_validator('abc')
+def test_lat_long_invalid_scale():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
 
-    def test_set_equal_valid(self):
-        # Given
-        set_equal_validator = validators.set_equal({'a', 'b', 'c'})
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator('1.567889')
 
-        # When
-        set_equal_validator(['a', 'b', 'c'])
 
-        # Then no invalid exception is raised
+def test_lat_long_invalid_precision():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=10, max_precision=5)
 
-    def test_set_equal_invalid(self):
-        # Given
-        set_equal_validator = validators.set_equal({'a', 'b', 'c'})
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator('123456.7')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            set_equal_validator(['a', 'b', 'c', 'blah'])
 
-    def test_no_padding_whitespace_check_valid(self):
-        # Given
-        no_padding_whitespace_validator = validators.no_padding_whitespace()
+def test_in_set_valid():
+    # Given
+    in_set_validator = validators.in_set({'a', 'b', 'c'})
 
-        # When
-        no_padding_whitespace_validator('')
+    # When
+    in_set_validator('a')
+    in_set_validator('b')
+    in_set_validator('c')
 
-        # Then no invalid exception is raised
+    # Then no invalid exception is raised
 
-    def test_no_padding_whitespace_check_invalid(self):
-        # Given
-        no_padding_whitespace_validator = validators.no_padding_whitespace()
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            no_padding_whitespace_validator('  ')
+def test_in_set_invalid():
+    # Given
+    in_set_validator = validators.in_set({'a'})
 
-    def test_no_pipe_character_check_valid(self):
-        # Given
-        no_pipe_character_validator = validators.no_pipe_character()
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        in_set_validator('abc')
 
-        # When, then raises
-        no_pipe_character_validator('test')
 
-        # Then no invalid exception is raised
+def test_set_equal_valid():
+    # Given
+    set_equal_validator = validators.set_equal({'a', 'b', 'c'})
 
-    def test_no_pipe_character_check_invalid(self):
-        # Given
-        no_pipe_character_validator = validators.no_pipe_character()
+    # When
+    set_equal_validator(['a', 'b', 'c'])
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            no_pipe_character_validator('|')
+    # Then no invalid exception is raised
 
-    def test_region_matches_treatment_code_valid(self):
-        # Given
-        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
 
-        # When
-        region_matches_treatment_code_validator('E0000', row={'TREATMENT_CODE': 'HH_TESTE'})
+def test_set_equal_invalid():
+    # Given
+    set_equal_validator = validators.set_equal({'a', 'b', 'c'})
 
-        # Then no invalid exception is raised
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        set_equal_validator(['a', 'b', 'c', 'blah'])
 
-    def test_region_matches_treatment_code_invalid(self):
-        # Given
-        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': 'HH_TESTE'})
+def test_no_padding_whitespace_check_valid():
+    # Given
+    no_padding_whitespace_validator = validators.no_padding_whitespace()
 
-    def test_region_matches_treatment_code_empty_region_no_error(self):
-        # Given
-        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+    # When
+    no_padding_whitespace_validator('')
 
-        # When, then doesn't error.
-        region_matches_treatment_code_validator(' ', row={'TREATMENT_CODE': 'HH_TESTE'})
+    # Then no invalid exception is raised
 
-    def test_region_matches_treatment_code_empty_treatment_no_error(self):
-        # Given
-        region_matches_treatment_code_validator = validators.region_matches_treatment_code()
 
-        # When, then doesn't error.
-        region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': ' '})
+def test_no_padding_whitespace_check_invalid():
+    # Given
+    no_padding_whitespace_validator = validators.no_padding_whitespace()
 
-    def test_ce_u_has_expected_capacity_valid(self):
-        # Given
-        ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        no_padding_whitespace_validator('  ')
 
-        # When
-        ce_u_has_expected_capacity_validator('5', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'U'})
 
-        # Then no invalid exception is raised
+def test_no_pipe_character_check_valid():
+    # Given
+    no_pipe_character_validator = validators.no_pipe_character()
 
-    def test_ce_u_has_expected_capacity_invalid(self):
-        # Given
-        ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()
+    # When, then raises
+    no_pipe_character_validator('test')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            ce_u_has_expected_capacity_validator('a', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'U'})
+    # Then no invalid exception is raised
 
-    def test_ce_e_has_expected_capacity_valid(self):
-        # Given
-        ce_e_has_expected_capacity_validator = validators.ce_e_has_expected_capacity()
 
-        # When
-        ce_e_has_expected_capacity_validator('5', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'E',
+def test_no_pipe_character_check_invalid():
+    # Given
+    no_pipe_character_validator = validators.no_pipe_character()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        no_pipe_character_validator('|')
+
+
+def test_region_matches_treatment_code_valid():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When
+    region_matches_treatment_code_validator('E0000', row={'TREATMENT_CODE': 'HH_TESTE'})
+
+    # Then no invalid exception is raised
+
+
+def test_region_matches_treatment_code_invalid():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': 'HH_TESTE'})
+
+
+def test_region_matches_treatment_code_empty_region_no_error():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When, then doesn't error.
+    region_matches_treatment_code_validator(' ', row={'TREATMENT_CODE': 'HH_TESTE'})
+
+
+def test_region_matches_treatment_code_empty_treatment_no_error():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When, then doesn't error.
+    region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': ' '})
+
+
+def test_ce_u_has_expected_capacity_valid():
+    # Given
+    ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()
+
+    # When
+    ce_u_has_expected_capacity_validator('5', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'U'})
+
+    # Then no invalid exception is raised
+
+
+def test_ce_u_has_expected_capacity_invalid():
+    # Given
+    ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        ce_u_has_expected_capacity_validator('a', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'U'})
+
+
+def test_ce_e_has_expected_capacity_valid():
+    # Given
+    ce_e_has_expected_capacity_validator = validators.ce_e_has_expected_capacity()
+
+    # When
+    ce_e_has_expected_capacity_validator('5', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'E',
+                                                   'TREATMENT_CODE': 'CE_TESTE'})
+
+    # Then no invalid exception is raised
+
+
+def test_ce_e_has_expected_capacity_invalid():
+    # Given
+    ce_e_has_expected_capacity_validator = validators.ce_e_has_expected_capacity()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        ce_e_has_expected_capacity_validator('0', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'E',
                                                        'TREATMENT_CODE': 'CE_TESTE'})
 
-        # Then no invalid exception is raised
 
-    def test_ce_e_has_expected_capacity_invalid(self):
-        # Given
-        ce_e_has_expected_capacity_validator = validators.ce_e_has_expected_capacity()
+def test_alphanumeric_postcode_valid():
+    # Given
+    alphanumeric_postcode_validator = validators.alphanumeric_postcode()
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            ce_e_has_expected_capacity_validator('0', row={'ADDRESS_TYPE': 'CE', 'ADDRESS_LEVEL': 'E',
-                                                           'TREATMENT_CODE': 'CE_TESTE'})
+    # When
+    alphanumeric_postcode_validator('TE25 5TE')
 
-    def test_alphanumeric_postcode_valid(self):
-        # Given
-        alphanumeric_postcode_validator = validators.alphanumeric_postcode()
+    # Then no invalid exception is raised
 
-        # When
-        alphanumeric_postcode_validator('TE25 5TE')
 
-        # Then no invalid exception is raised
+def test_alphanumeric_postcode_invalid():
+    # Given
+    alphanumeric_postcode_validator = validators.alphanumeric_postcode()
 
-    def test_alphanumeric_postcode_invalid(self):
-        # Given
-        alphanumeric_postcode_validator = validators.alphanumeric_postcode()
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        alphanumeric_postcode_validator('TE5 5TE!')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            alphanumeric_postcode_validator('TE5 5TE!')
 
-    def test_latitude_longitude_range_valid(self):
-        # Given
-        latitude_longitude_range_validator = validators.latitude_longitude_range()
+def test_latitude_longitude_range_valid():
+    # Given
+    latitude_longitude_range_validator = validators.latitude_longitude_range()
 
-        # When
-        latitude_longitude_range_validator(50)
+    # When
+    latitude_longitude_range_validator(50)
 
-        # Then no invalid exception is raised
+    # Then no invalid exception is raised
 
-    def test_latitude_longitude_range_invalid(self):
-        # Given
-        latitude_longitude_range_validator = validators.latitude_longitude_range()
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            latitude_longitude_range_validator(360)
+def test_latitude_longitude_range_invalid():
+    # Given
+    latitude_longitude_range_validator = validators.latitude_longitude_range()
 
-    def test_alphanumeric_plus_hyphen_field_values_valid(self):
-        # Given
-        alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        latitude_longitude_range_validator(360)
 
-        # When
-        alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-01')
 
-        # Then no invalid exception is raised
+def test_alphanumeric_plus_hyphen_field_values_valid():
+    # Given
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
 
-    def test_alphanumeric_plus_hyphen_field_values_invalid(self):
-        # Given
-        alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
+    # When
+    alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-01')
 
-        # When, then raises
-        with pytest.raises(validators.Invalid):
-            alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-!!')
+    # Then no invalid exception is raised
+
+
+def test_alphanumeric_plus_hyphen_field_values_invalid():
+    # Given
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-!!')

--- a/validators.py
+++ b/validators.py
@@ -49,6 +49,8 @@ def latitude_longitude(max_precision: int, max_scale: int):
         except ValueError:
             raise Invalid(f'Value "{value}" is not a valid float')
         try:
+            # This will fail validation correctly if given a value with none or multiple '.'s
+            # as this line raises ValueError if it cannot unpack into 2 variables. 
             integer, decimal = value.split('.')
             int(integer)
             int(decimal)

--- a/validators.py
+++ b/validators.py
@@ -50,7 +50,7 @@ def latitude_longitude(max_precision: int, max_scale: int):
             raise Invalid(f'Value "{value}" is not a valid float')
         try:
             # This will fail validation correctly if given a value with none or multiple '.'s
-            # as this line raises ValueError if it cannot unpack into 2 variables. 
+            # as this line raises ValueError if it cannot unpack into 2 variables.
             integer, decimal = value.split('.')
             int(integer)
             int(decimal)

--- a/validators.py
+++ b/validators.py
@@ -50,6 +50,8 @@ def latitude_longitude(max_precision: int, max_scale: int):
             raise Invalid(f'Value "{value}" is not a valid float')
         try:
             integer, decimal = value.split('.')
+            int(integer)
+            int(decimal)
         except ValueError:
             raise Invalid(f'Malformed decimal, Value = "{value}"')
         integer = integer.strip('-')


### PR DESCRIPTION
## Why
Python will happily parse scientific notation strings into floats, we want to enforce that the lat long values are explicit decimals.

## What
* Check the lat long values can be split on the `.` into two integer values
* Remove unittest  testcase as it conflicts with pytest parameterize 

## Whence
https://trello.com/c/P0eOChVi/1638-sample-validator-should-fail-on-any-non-explicitly-decimal-format-lat-long