### PR TITLE
feature/rabbitmq-kubernetes-operator

### DIFF
--- a/run_in_kubernetes.sh
+++ b/run_in_kubernetes.sh
@@ -11,7 +11,7 @@ kubectl run sampleloader -it --rm \
    --image $IMAGE\
    --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
    --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
-   --env=RABBITMQ_SERVICE_HOST=rm-rabbitmq-client \
+   --env=RABBITMQ_SERVICE_HOST=rm-rabbitmq \
    --env=RABBITMQ_SERVICE_PORT=5672 \
    --env=RABBITMQ_QUEUE='case.sample.inbound' \
    --env=RABBITMQ_VHOST='/' \

--- a/run_in_kubernetes.sh
+++ b/run_in_kubernetes.sh
@@ -11,7 +11,7 @@ kubectl run sampleloader -it --rm \
    --image $IMAGE\
    --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
    --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
-   --env=RABBITMQ_SERVICE_HOST=rabbitmq \
+   --env=RABBITMQ_SERVICE_HOST=rm-rabbitmq-client \
    --env=RABBITMQ_SERVICE_PORT=5672 \
    --env=RABBITMQ_QUEUE='case.sample.inbound' \
    --env=RABBITMQ_VHOST='/' \


### PR DESCRIPTION
Replacing the RabbitMQ cluster setup to use Kubernetes Operator instead of the deprecated helm chart.